### PR TITLE
Add engine files group

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ Shareable config presets for akashic-games.
 
 ### engineFilesAlias
 
-* `@akashic/engine-files@v*` のエイリアス `aev*` の設定。このルールを利用するには `@akashic/engine-files@v*` を利用するモジュール側の package.json で `aev*` をエイリアスにする必要があります。
+* `@akashic/engine-files@v*` のエイリアス `engine-files-v*` の設定。このルールを利用するには `@akashic/engine-files@v*` を利用するモジュール側の package.json で `engine-files-v*` をエイリアスにする必要があります。
 
 ```json
 "dependencies": {
-  "aev3": "npm:@akashic/engine-files@3.x.x"
+  "engine-files-v3": "npm:@akashic/engine-files@3.x.x"
 }
 ```
 
 #### engineFilesAlias/update
 
-*  `aev*` を "at any time" で更新する
+*  `engine-files-v*` を "at any time" で更新する
 
 ```json
 {
@@ -67,7 +67,7 @@ Shareable config presets for akashic-games.
 
 #### engineFilesAlias/automerge
 
-* `aev*` の PullRequest を auto-merge する
+* `engine-files-v*` の PullRequest を auto-merge する
 
 ```json
 {
@@ -77,7 +77,7 @@ Shareable config presets for akashic-games.
 
 #### engineFilesAlias/bump
 
-* `aev*` の patch が更新されていれば patch version をすすめ、 minor が更新されていれば minor version をすすめる
+* `engine-files-v*` の patch が更新されていれば patch version をすすめ、 minor が更新されていれば minor version をすすめる
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Shareable config presets for akashic-games.
 }
 ```
 
-### engineFilesAlias/bump
+#### engineFilesAlias/bump
 
-* `aev*` の patch, minor 更新に応じて自身のバージョンをすすめる
+* `aev*` の patch が更新されていれば patch version を, minor が更新されていれば minor version をすすめる
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Shareable config presets for akashic-games.
 
 ### engineFilesAlias
 
-* `@akashic/engine-files@v*` のエイリアスの設定。このルールを利用するには `@akashic/engine-files@v*` を利用するモジュール側の package.json で `aev*` をエイリアスにする必要があります。
+* `@akashic/engine-files@v*` のエイリアス `aev*` の設定。このルールを利用するには `@akashic/engine-files@v*` を利用するモジュール側の package.json で `aev*` をエイリアスにする必要があります。
 
 ```json
 "dependencies": {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Shareable config presets for akashic-games.
 
 #### engineFilesAlias/bump
 
-* `aev*` の patch が更新されていれば patch version を, minor が更新されていれば minor version をすすめる
+* `aev*` の patch が更新されていれば patch version をすすめ、 minor が更新されていれば minor version をすすめる
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Shareable config presets for akashic-games.
 ```
 
 ### groupEngineFiles
-* `engine-files` の更新を patch, minor ごとに PullRequest をまとめ、patch, minor に対応したpackage.json の version をすすめる
+* `engine-files` の更新を patch, minor で PullRequest を作成し、patch, minor に対応したpackage.json の version をすすめる
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -44,3 +44,12 @@ Shareable config presets for akashic-games.
   "extends": ["github>akashic-games/renovate-config:groupAll"]
 }
 ```
+
+### groupEngineFiles
+* `engine-files` の更新を patch, minor ごとに PullRequest をまとめ、patch, minor に対応したpackage.json の version をすすめる
+
+```json
+{
+  "extends": ["github>akashic-games/renovate-config:groupEngineFiles"]
+}
+```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,19 @@ Shareable config presets for akashic-games.
 }
 ```
 
-### engineFilesAlias/update
+### engineFilesAlias
 
-* `@akashic/engine-files@v*` のエイリアス `aev*` を "at any time" で更新する
+* `@akashic/engine-files@v*` のエイリアスの設定。このルールを利用するには `@akashic/engine-files@v*` を利用するモジュール側の package.json で `aev*` をエイリアスにする必要があります。
+
+```json
+"dependencies": {
+  "aev3": "npm:@akashic/engine-files@3.x.x"
+}
+```
+
+#### engineFilesAlias/update
+
+*  `aev*` を "at any time" で更新する
 
 ```json
 {
@@ -55,9 +65,9 @@ Shareable config presets for akashic-games.
 }
 ```
 
-### engineFilesAlias/automerge
+#### engineFilesAlias/automerge
 
-* `@akashic/engine-files@v*` のエイリアス `aev*` の PullRequest を auto-merge する
+* `aev*` の PullRequest を auto-merge する
 
 ```json
 {
@@ -67,7 +77,7 @@ Shareable config presets for akashic-games.
 
 ### engineFilesAlias/bump
 
-* `@akashic/engine-files@v*` のエイリアス `aev*` の patch, minor 更新に応じて自身のバージョンをすすめる
+* `aev*` の patch, minor 更新に応じて自身のバージョンをすすめる
 
 ```json
 {
@@ -75,7 +85,7 @@ Shareable config presets for akashic-games.
 }
 ```
 
-### engineFilesAlias/bump
+#### engineFilesAlias/default
 
 * `engineFilesAlias/` 配下の `update`, `automerge`, `bump` を合わせたルール
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Shareable config presets for akashic-games.
 
 ### engineFilesAlias
 
-* `@akashic/engine-files@v*` のエイリアス `engine-files-v*` の設定。このルールを利用するには `@akashic/engine-files@v*` を利用するモジュール側の package.json で `engine-files-v*` をエイリアスにする必要があります。
+`@akashic/engine-files@v*` のエイリアス `engine-files-v*` の設定。
+
+このルールは利用側で `@akashic/engine-files@v*` を `engine-files-v*` にエイリアスしていることを前提としています。
 
 ```json
 "dependencies": {
@@ -57,7 +59,7 @@ Shareable config presets for akashic-games.
 
 #### engineFilesAlias/update
 
-*  `engine-files-v*` を "at any time" で更新する
+*  `engine-files-v*` モジュールは即時に PullRequest を作成する
 
 ```json
 {
@@ -77,7 +79,7 @@ Shareable config presets for akashic-games.
 
 #### engineFilesAlias/bump
 
-* `engine-files-v*` の patch が更新されていれば patch version をすすめ、 minor が更新されていれば minor version をすすめる
+* `engine-files-v*` の patch が更新されていれば package.json の patch version をすすめ、 minor が更新されていれば minor version をすすめる
 
 ```json
 {
@@ -87,7 +89,10 @@ Shareable config presets for akashic-games.
 
 #### engineFilesAlias/default
 
-* `engineFilesAlias/` 配下の `update`, `automerge`, `bump` を合わせたルール
+* 以下を合わせたルールを利用する
+  * `engineFilesAlias/update`
+  * `engineFilesAlias/automerge`
+  * `engineFilesAlias/bump`
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -45,11 +45,42 @@ Shareable config presets for akashic-games.
 }
 ```
 
-### groupEngineFiles
-* `engine-files` の更新を patch, minor で PullRequest を作成し、patch, minor に対応したpackage.json の version をすすめる
+### engineFilesAlias/update
+
+* `@akashic/engine-files@v*` のエイリアス `aev*` を "at any time" で更新する
 
 ```json
 {
-  "extends": ["github>akashic-games/renovate-config:groupEngineFiles"]
+  "extends": ["github>akashic-games/renovate-config//engineFilesAlias/update"]
+}
+```
+
+### engineFilesAlias/automerge
+
+* `@akashic/engine-files@v*` のエイリアス `aev*` の PullRequest を auto-merge する
+
+```json
+{
+  "extends": ["github>akashic-games/renovate-config//engineFilesAlias/automerge"]
+}
+```
+
+### engineFilesAlias/bump
+
+* `@akashic/engine-files@v*` のエイリアス `aev*` の patch, minor 更新に応じて自身のバージョンをすすめる
+
+```json
+{
+  "extends": ["github>akashic-games/renovate-config//engineFilesAlias/bump"]
+}
+```
+
+### engineFilesAlias/bump
+
+* `engineFilesAlias/` 配下の `update`, `automerge`, `bump` を合わせたルール
+
+```json
+{
+  "extends": ["github>akashic-games/renovate-config//engineFilesAlias/default"]
 }
 ```

--- a/engineFilesAlias/automerge.json
+++ b/engineFilesAlias/automerge.json
@@ -1,0 +1,16 @@
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["aev1"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["aev3"],
+      "automerge": true
+    }
+  ]
+}

--- a/engineFilesAlias/automerge.json
+++ b/engineFilesAlias/automerge.json
@@ -1,15 +1,15 @@
 {
   "packageRules": [
     {
-      "matchPackageNames": ["aev1"],
+      "matchPackageNames": ["engine-files-v1"],
       "automerge": true
     },
     {
-      "matchPackageNames": ["aev2"],
+      "matchPackageNames": ["engine-files-v2"],
       "automerge": true
     },
     {
-      "matchPackageNames": ["aev3"],
+      "matchPackageNames": ["engine-files-v3"],
       "automerge": true
     }
   ]

--- a/engineFilesAlias/bump.json
+++ b/engineFilesAlias/bump.json
@@ -2,12 +2,6 @@
   "packageRules": [
     {
       "matchPackageNames": ["aev1"],
-      "allowedVersions": "<2.0",
-      "groupName": "engine-files@1",
-      "schedule": "at any time"
-    },
-    {
-      "matchPackageNames": ["aev1"],
       "matchUpdateTypes": ["patch"],
       "bumpVersion": "patch"
     },
@@ -18,12 +12,6 @@
     },
     {
       "matchPackageNames": ["aev2"],
-      "allowedVersions": "<3.0",
-      "groupName": "engine-files@2",
-      "schedule": "at any time"
-    },
-    {
-      "matchPackageNames": ["aev2"],
       "matchUpdateTypes": ["patch"],
       "bumpVersion": "patch"
     },
@@ -31,12 +19,6 @@
       "matchPackageNames": ["aev2"],
       "matchUpdateTypes": ["minor"],
       "bumpVersion": "minor"
-    },
-    {
-      "matchPackageNames": ["aev3"],
-      "allowedVersions": "<4.0",
-      "groupName": "engine-files@3",
-      "schedule": "at any time"
     },
     {
       "matchPackageNames": ["aev3"],

--- a/engineFilesAlias/bump.json
+++ b/engineFilesAlias/bump.json
@@ -1,32 +1,32 @@
 {
   "packageRules": [
     {
-      "matchPackageNames": ["aev1"],
+      "matchPackageNames": ["engine-files-v1"],
       "matchUpdateTypes": ["patch"],
       "bumpVersion": "patch"
     },
     {
-      "matchPackageNames": ["aev1"],
+      "matchPackageNames": ["engine-files-v1"],
       "matchUpdateTypes": ["minor"],
       "bumpVersion": "minor"
     },
     {
-      "matchPackageNames": ["aev2"],
+      "matchPackageNames": ["engine-files-v2"],
       "matchUpdateTypes": ["patch"],
       "bumpVersion": "patch"
     },
     {
-      "matchPackageNames": ["aev2"],
+      "matchPackageNames": ["engine-files-v2"],
       "matchUpdateTypes": ["minor"],
       "bumpVersion": "minor"
     },
     {
-      "matchPackageNames": ["aev3"],
+      "matchPackageNames": ["engine-files-v3"],
       "matchUpdateTypes": ["patch"],
       "bumpVersion": "patch"
     },
     {
-      "matchPackageNames": ["aev3"],
+      "matchPackageNames": ["engine-files-v3"],
       "matchUpdateTypes": ["minor"],
       "bumpVersion": "minor"
     }

--- a/engineFilesAlias/default.json
+++ b/engineFilesAlias/default.json
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    "github>ShinobuTakahashi/renovate-config//engineFilesAlias/update",
+    "github>ShinobuTakahashi/renovate-config//engineFilesAlias/automerge",
+    "github>ShinobuTakahashi/renovate-config//engineFilesAlias/bump"
+  ]
+}

--- a/engineFilesAlias/default.json
+++ b/engineFilesAlias/default.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "github>ShinobuTakahashi/renovate-config//engineFilesAlias/update",
-    "github>ShinobuTakahashi/renovate-config//engineFilesAlias/automerge",
-    "github>ShinobuTakahashi/renovate-config//engineFilesAlias/bump"
+    "github>akashic-games/renovate-config//engineFilesAlias/update",
+    "github>akashic-games/renovate-config//engineFilesAlias/automerge",
+    "github>akashic-games/renovate-config//engineFilesAlias/bump"
   ]
 }

--- a/engineFilesAlias/update.json
+++ b/engineFilesAlias/update.json
@@ -1,19 +1,19 @@
 {
   "packageRules": [
     {
-      "matchPackageNames": ["aev1"],
+      "matchPackageNames": ["engine-files-v1"],
       "allowedVersions": "<2.0",
       "groupName": "engine-files@1",
       "schedule": "at any time"
     },
     {
-      "matchPackageNames": ["aev2"],
+      "matchPackageNames": ["engine-files-v2"],
       "allowedVersions": "<3.0",
       "groupName": "engine-files@2",
       "schedule": "at any time"
     },
     {
-      "matchPackageNames": ["aev3"],
+      "matchPackageNames": ["engine-files-v3"],
       "allowedVersions": "<4.0",
       "groupName": "engine-files@3",
       "schedule": "at any time"

--- a/engineFilesAlias/update.json
+++ b/engineFilesAlias/update.json
@@ -1,0 +1,22 @@
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["aev1"],
+      "allowedVersions": "<2.0",
+      "groupName": "engine-files@1",
+      "schedule": "at any time"
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "allowedVersions": "<3.0",
+      "groupName": "engine-files@2",
+      "schedule": "at any time"
+    },
+    {
+      "matchPackageNames": ["aev3"],
+      "allowedVersions": "<4.0",
+      "groupName": "engine-files@3",
+      "schedule": "at any time"
+    }
+  ]
+}

--- a/groupEngineFiles.json
+++ b/groupEngineFiles.json
@@ -1,0 +1,52 @@
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["aev1"],
+      "allowedVersions": "<2.0",
+      "groupName": "engine-files@1",
+      "schedule": "at any time"
+    },
+    {
+      "matchPackageNames": ["aev1"],
+      "matchUpdateTypes": ["patch"],
+      "bumpVersion": "patch"
+    },
+    {
+      "matchPackageNames": ["aev1"],
+      "matchUpdateTypes": ["minor"],
+      "bumpVersion": "minor"
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "allowedVersions": "<3.0",
+      "groupName": "engine-files@2",
+      "schedule": "at any time"
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "matchUpdateTypes": ["patch"],
+      "bumpVersion": "patch"
+    },
+    {
+      "matchPackageNames": ["aev2"],
+      "matchUpdateTypes": ["minor"],
+      "bumpVersion": "minor"
+    },
+    {
+      "matchPackageNames": ["aev3"],
+      "allowedVersions": "<4.0",
+      "groupName": "engine-files@3",
+      "schedule": "at any time"
+    },
+    {
+      "matchPackageNames": ["aev3"],
+      "matchUpdateTypes": ["patch"],
+      "bumpVersion": "patch"
+    },
+    {
+      "matchPackageNames": ["aev3"],
+      "matchUpdateTypes": ["minor"],
+      "bumpVersion": "minor"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

engineFiles 利用モジュールの renovate 設定の共通化。

動作確認
sandbox, headless-driver をフォークした個人リポジトリで、engineFiles の path/minor のPRが既存動作で作成されることを確認。
 [patch](https://github.com/ShinobuTakahashi/headless-driver/pulls)
[minor](https://github.com/ShinobuTakahashi/akashic-sandbox/pulls)
