### PR TITLE
wait to update external modules with 7 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Shareable config presets for akashic-games.
 
 * `@akashic` モジュールは即時に PullRequest を作成する
 * それ以外のモジュールは業務時間外に PullRequest を作成する
+* `@akashic` モジュール以外の PullRequest は更新から7日以上経過したもののみ更新する内容になっている
+  * `@akashic` モジュールの PullRequest は更新から即日更新する内容になっている
 
 ```json
 {

--- a/default.json
+++ b/default.json
@@ -17,10 +17,15 @@
   ],
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "matchPackagePatterns": ["^@akashic/"],
       "schedule": "at any time",
       "groupName": "akashic packages",
-      "groupSlug": "akashic-dependencies"
+      "groupSlug": "akashic-dependencies",
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
### 概要
- 外部のnpmモジュール起因でのセキュリティインシデント対策として各リポジトリ共通のrenovate設定ファイルに、「npmモジュールの更新反映を、更新から7日間待つ」設定を追加しました。
  - `automerge: true`としている各リポジトリのrenovate.jsonに書くべきかと思いましたが、セキュリティインシデント対策なので全リポジトリ共通の設定にしてもいいのではという判断で、この対応を行いました。

### やったこと
- 以下の設定を追加
  - npmモジュールの更新反映を、更新から7日間待つ
  - ただし`@akashic`モジュールに関しては更新後即反映する